### PR TITLE
Use sops/decrypt package for config loading

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,15 +2,13 @@ package main
 
 import (
 	"io/ioutil"
-	"os"
-	"time"
+	"log"
 
 	yaml "gopkg.in/yaml.v2"
 
 	"go.mozilla.org/mozldap"
 	"go.mozilla.org/sops"
-	"go.mozilla.org/sops/aes"
-	sopsyaml "go.mozilla.org/sops/yaml"
+	"go.mozilla.org/sops/decrypt"
 	"go.mozilla.org/userplex/modules"
 )
 
@@ -41,61 +39,24 @@ type conf struct {
 }
 
 func loadConf(path string) (cfg conf, err error) {
-	var data []byte
-	// read configuration from stdin if no config file was
-	// passed in command line arguments
-	if *config == "" {
-		data, err = ioutil.ReadAll(os.Stdin)
-	} else {
-		data, err = ioutil.ReadFile(*config)
-	}
+	log.Println("Accessing configuration from", path)
+	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return
 	}
-	// try to decrypt the conf using sops or load it as plaintext
-	// if it's not encrypted
-	decryptedConf, err := decryptConf(data)
+	// Try to decrypt the conf using sops or load it as plaintext.
+	// If the configuration is not encrypted with sops, the error
+	// sops.MetadataNotFound will be returned, in which case we
+	// ignore it and continue loading the conf.
+	confData, err := decrypt.Data(data, "yaml")
 	if err != nil {
-		// decryption would have failed if the file is not encrypted,
-		// in which case simply continue loading as yaml. But if the
-		// file is encrypted and decryption failed, exit here.
-		if err != sops.MetadataNotFound {
+		if err.Error() == sops.MetadataNotFound.Error() {
+			// not an encrypted file
+			confData = data
+		} else {
 			return
 		}
-	} else {
-		data = decryptedConf
 	}
-	err = yaml.Unmarshal(data, &cfg)
+	err = yaml.Unmarshal(confData, &cfg)
 	return
-}
-
-func decryptConf(encryptedConf []byte) (decryptedConf []byte, err error) {
-	store := &sopsyaml.Store{}
-	metadata, err := store.UnmarshalMetadata(encryptedConf)
-	if err != nil {
-		return
-	}
-	key, err := metadata.GetDataKey()
-	if err != nil {
-		return
-	}
-	branch, err := store.Unmarshal(encryptedConf)
-	if err != nil {
-		return
-	}
-	tree := sops.Tree{Branch: branch, Metadata: metadata}
-	cipher := aes.Cipher{}
-	mac, err := tree.Decrypt(key, cipher)
-	if err != nil {
-		return
-	}
-	originalMac, err := cipher.Decrypt(
-		metadata.MessageAuthenticationCode,
-		key,
-		[]byte(metadata.LastModified.Format(time.RFC3339)),
-	)
-	if originalMac != mac {
-		return
-	}
-	return store.Marshal(tree.Branch)
 }


### PR DESCRIPTION
The other packages don't have a stable API, so using the decrypt package
is better.

Basically copied from https://github.com/mozilla-services/autograph/blob/b22f768022290da9c7b7b44674254e94e1408909/tools/autograph-monitor/monitor.go#L107-L132