### PR TITLE
Add ignore_usernames feature to AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,7 @@ dev: lint cyclo all
 install:
 	$(GO) install $(PROJECT)
 
-vendor:
-	$(GO) mod tidy
-	$(GO) mod vendor
-
-test: vendor
+test:
 	./test.sh
 
 lint:
@@ -53,4 +49,4 @@ rpm-pkg: install
 		-v "$$(git describe --abbrev=0 --tags)" \
 		-s dir -t rpm .
 
-.PHONY: all test clean install vendor
+.PHONY: all test clean install

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ notifications:
 aws:
   - account_name: "myawsaccount"
     notify_new_users: true
+    ignore_usernames:
+      - legacy_user
     credentials:
         # if blank, will use the default aws credential flow
         access_key: AKIAnnnn

--- a/config.yaml
+++ b/config.yaml
@@ -37,6 +37,8 @@ notifications:
 aws:
   - account_name: "myawsaccount"
     notify_new_users: true
+    ignore_usernames:
+      - legacy_user
     credentials:
         # if blank, will use the default aws credential flow
         access_key: AKIAnnnn

--- a/modules/aws/aws.go
+++ b/modules/aws/aws.go
@@ -634,11 +634,24 @@ func (awsm *AWSModule) verifyAWSUsers(allLdapUsers []*person_api.Person) ([]Veri
 		return nil, err
 	}
 
+	filteredIAMUsers := []*iam.User{}
+	for _, iamUser := range iamUsers {
+		toBeIgnored := false
+		for _, username := range awsm.config.IgnoreUsernames {
+			if *iamUser.UserName == username {
+				toBeIgnored = true
+			}
+		}
+		if !toBeIgnored {
+			filteredIAMUsers = append(filteredIAMUsers, iamUser)
+		}
+	}
+
 	for _, ldapUser := range allLdapUsers {
 		ldapUsernames[awsm.LDAPUsernameToLocalUsername(ldapUser.GetLDAPUsername(), awsm.config.UsernameMap)] = ldapUser
 	}
 
-	for _, user := range iamUsers {
+	for _, user := range filteredIAMUsers {
 		inLdap := false
 		vr := VerifyResult{AWSUsername: *user.UserName}
 

--- a/modules/aws/aws_test.go
+++ b/modules/aws/aws_test.go
@@ -272,6 +272,7 @@ func TestVerify(t *testing.T) {
 		listUsersOutput: &iam.ListUsersOutput{
 			Users: []*iam.User{
 				{UserName: aws.String("success")},
+				{UserName: aws.String("ignored")},
 				{UserName: aws.String("not_in_ldap")},
 				{UserName: aws.String("extra_groups")},
 			},
@@ -287,6 +288,7 @@ func TestVerify(t *testing.T) {
 		iam:        &iamMock,
 		ec2:        mockEc2{},
 		config: &modules.AWSConfiguration{
+			IgnoreUsernames: []string{"ignored"},
 			GroupMappings: []modules.GroupMapping{
 				{LdapGroup: "test", IamGroups: []string{"test"}},
 				{LdapGroup: "extra", IamGroups: []string{"extra"}},

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -62,7 +62,8 @@ type GroupMapping struct {
 
 type AWSConfiguration struct {
 	BaseConfiguration `yaml:",inline"`
-	AccountName       string `yaml:"account_name"`
+	AccountName       string   `yaml:"account_name"`
+	IgnoreUsernames   []string `yaml:"ignore_usernames"`
 	Credentials       struct {
 		AccessKey string `yaml:"access_key"`
 		SecretKey string `yaml:"secret_key"`


### PR DESCRIPTION
Adds support for an `ignore_usernames` field in the AWS config that supports a list of IAM usernames in AWS that will be ignored for that AWS account.

i.e.:
```yaml
aws:
  - account_name: "myawsaccount"
    notify_new_users: true
    ignore_usernames:
      - legacy_user
...
```